### PR TITLE
Update from per-object UBOs to Dynamic UBO

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+```bash
+# Initial setup (from project root)
+mkdir build
+cd build
+cmake ..
+
+# Build the project
+make
+
+# Build with parallel jobs
+make -j8
+
+# Clean build
+make clean
+
+# Rebuild from scratch
+rm -rf build && mkdir build && cd build && cmake .. && make
+
+# Compile shaders only
+make CompileShaders
+
+# Run the application (from build directory)
+./3dObjViewer
+```
+
+## Architecture Overview
+
+This is a Vulkan-based 3D object viewer with a layered architecture:
+
+1. **Vulkan Layer** (`src/vulkan/`): Low-level Vulkan abstractions
+   - `VulkanEngine`: Main Vulkan initialization and management
+   - `VulkanDevice`: Physical/logical device and queue management
+   - `VulkanSwapchain`: Presentation surface management
+   - `VulkanBuffer`: Vertex/index/uniform buffer abstractions
+   - `VulkanPipeline`: Graphics pipeline configuration
+
+2. **Rendering Layer** (`src/rendering/`): High-level rendering components
+   - `Renderer`: Coordinates rendering operations, manages per-object transforms
+   - `Camera`: View/projection matrix generation with FPS-style controls
+   - `DynamicUBO`: Dynamic uniform buffer management for per-object transforms
+   - `Object`: Represents renderable objects with world positions
+   - `Mesh`: Vertex/index data container
+
+3. **Geometry Layer** (`src/geometry/`): 3D model loading and generation
+   - `Model`: High-level model representation
+   - `ObjLoader`: Parses .obj files from `assets/` directory
+   - `GeometryGenerator`: Creates procedural geometry (cubes, spheres)
+
+4. **Math Layer** (`src/math/`): Custom math implementations
+   - Uses column-major matrices for Vulkan compatibility
+   - Matrix multiplication order: projection * view * model
+
+## Key Technical Details
+
+### Shader System
+- Shaders in `shaders/` directory use `.vert.glsl` and `.frag.glsl` extensions
+- Compiled to SPIR-V during build via `glslangValidator`
+- Vertex shader expects: position (vec3), normal (vec3), color (vec3)
+- Uniform buffer: separate matrices for model, view, projection
+
+### Rendering Pipeline
+- Multiple objects share vertex/index buffers but have unique world transforms
+- Dynamic UBO system allocates per-object uniform data
+- Push constants used for per-object model matrices
+- Fixed camera controls: WASD (move), QE (up/down), Arrow keys (rotate)
+
+### Current Active Development (dynamicUBO branch)
+- Implementing dynamic uniform buffer objects for per-model transforms
+- New files: `DynamicUBO.cpp/h`, `Object.cpp/h`
+- Modified: `Renderer.cpp/h` for per-object rendering
+
+## Known Issues & Notes
+
+- The project was AI-generated as a Vulkan learning experiment
+- Rendering issues may exist with projection matrices or transform calculations
+- The codebase prioritizes clean architecture over optimization
+- SDL2 is used for windowing and input, not rendering
+
+## Testing
+
+Currently no automated tests. Manual testing involves:
+1. Building the project
+2. Running `./3dObjViewer` from build directory
+3. Testing camera controls and object rendering
+4. Loading different .obj files from assets directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SOURCES
     src/rendering/Camera.cpp
     src/rendering/Light.cpp
     src/rendering/Mesh.cpp
+    src/rendering/DynamicUBO.cpp
     
     # Geometry
     src/geometry/Model.cpp
@@ -73,6 +74,7 @@ set(HEADERS
     src/rendering/Camera.h
     src/rendering/Light.h
     src/rendering/Mesh.h
+    src/rendering/DynamicUBO.h
     
     # Geometry
     src/geometry/Model.h

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -185,8 +185,8 @@ void Application::setupScene() {
     camera->setTarget(Vector3(0.0f, 0.0f, 0.0f));
     camera->setUp(Vector3(0.0f, 1.0f, 0.0f));
 
-    // Add yaw rotation of -90 degrees to mimic manual turn necessary to center view to top of scene:
-    camera->rotate(Vector3(0.0f, -90.0f, 0.0f));
+    // At program start, scene is outside view, so hack the yaw/pitch (temporary)
+    camera->rotate(Vector3(12.0f, -90.0f, 0.0f));
 
     // Set perspective with proper aspect ratio
     float aspect = static_cast<float>(windowWidth) / static_cast<float>(windowHeight);

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -180,11 +180,13 @@ void Application::setupScene() {
 
     camera = std::make_unique<Camera>();
 
-    // FIXED: Camera should look along -Z in Vulkan
     // Position camera back along +Z axis, looking toward origin
-    camera->setPosition(Vector3(0.0f, 2.0f, -8.0f));  // Note: NEGATIVE Z
-    camera->setTarget(Vector3(0.0f, 0.0f, 0.0f));      // Looking at origin
-    camera->setUp(Vector3(0.0f, 1.0f, 0.0f));          // Y is up
+    camera->setPosition(Vector3(0.0f, 2.0f, -8.0f));
+    camera->setTarget(Vector3(0.0f, 0.0f, 0.0f));
+    camera->setUp(Vector3(0.0f, 1.0f, 0.0f));
+
+    // Add yaw rotation of -90 degrees to mimic manual turn necessary to center view to top of scene:
+    camera->rotate(Vector3(0.0f, -90.0f, 0.0f));
 
     // Set perspective with proper aspect ratio
     float aspect = static_cast<float>(windowWidth) / static_cast<float>(windowHeight);

--- a/src/geometry/ObjLoader.cpp
+++ b/src/geometry/ObjLoader.cpp
@@ -187,20 +187,19 @@ void ObjLoader::parseFace(const std::string& line, ObjData& data) {
         faceVertices.push_back(fv);
     }
 
-    // Triangulate face with CORRECT counter-clockwise winding for Vulkan
-    // The OBJ format typically uses counter-clockwise winding when viewed from outside
-    // We need to maintain that for Vulkan
+    // Triangulate face with counter-clockwise winding
+    // Reverse triangle order to ensure counter-clockwise winding
     for (size_t i = 1; i < faceVertices.size() - 1; ++i) {
-        // Triangle fan triangulation maintaining CCW order
+        // Triangle fan triangulation with reversed order for CCW
         data.faceVertices.push_back(faceVertices[0]);
-        data.faceVertices.push_back(faceVertices[i]);
         data.faceVertices.push_back(faceVertices[i + 1]);
+        data.faceVertices.push_back(faceVertices[i]);
 
         // Also store simple indices if no separate normal indices
         if (faceVertices[0].normalIndex == -1) {
             data.indices.push_back(faceVertices[0].positionIndex);
-            data.indices.push_back(faceVertices[i].positionIndex);
             data.indices.push_back(faceVertices[i + 1].positionIndex);
+            data.indices.push_back(faceVertices[i].positionIndex);
         }
     }
 }

--- a/src/rendering/Camera.cpp
+++ b/src/rendering/Camera.cpp
@@ -67,6 +67,7 @@ void Camera::rotate(const Vector3& deltaRotation) {
     forward.z = std::sin(yawRad) * std::cos(pitchRad);
     forward.normalize();
 
+    // Update target based on new rotation
     target = position + forward;
     viewMatrixDirty = true;
 }

--- a/src/rendering/DynamicUBO.cpp
+++ b/src/rendering/DynamicUBO.cpp
@@ -1,0 +1,139 @@
+#include "DynamicUBO.h"
+#include "vulkan/VulkanDevice.h"
+#include "math/Matrix4.h"
+#include <stdexcept>
+#include <cstring>
+#include <algorithm>
+#include <iostream>
+
+DynamicUBO::DynamicUBO(VulkanDevice* device, uint32_t maxObjects, uint32_t framesInFlight)
+    : device(device)
+    , maxObjects(maxObjects)
+    , framesInFlight(framesInFlight)
+    , alignedObjectSize(0)
+    , totalBufferSize(0) {
+
+    // Get the minimum uniform buffer offset alignment requirement
+    VkPhysicalDeviceProperties deviceProps;
+    vkGetPhysicalDeviceProperties(device->getPhysicalDevice(), &deviceProps);
+    size_t minAlignment = deviceProps.limits.minUniformBufferOffsetAlignment;
+
+    // Calculate aligned size for each object's data
+    size_t objectSize = sizeof(PerObjectData);
+
+    // Align to GPU requirements
+    alignedObjectSize = static_cast<uint32_t>((objectSize + minAlignment - 1) & ~(minAlignment - 1));
+
+    // Total buffer size for all objects
+    totalBufferSize = alignedObjectSize * maxObjects;
+
+    std::cout << "DynamicUBO: Creating buffers for " << maxObjects << " objects\n";
+    std::cout << "  Object size: " << objectSize << " bytes\n";
+    std::cout << "  Aligned size: " << alignedObjectSize << " bytes\n";
+    std::cout << "  Min alignment: " << minAlignment << " bytes\n";
+    std::cout << "  Total buffer size per frame: " << totalBufferSize << " bytes\n";
+
+    createBuffers();
+}
+
+DynamicUBO::~DynamicUBO() {
+    cleanupBuffers();
+}
+
+void DynamicUBO::createBuffers() {
+    buffers.resize(framesInFlight);
+    memories.resize(framesInFlight);
+    mappedMemory.resize(framesInFlight);
+
+    for (uint32_t i = 0; i < framesInFlight; ++i) {
+        // Create buffer
+        VkBufferCreateInfo bufferInfo{};
+        bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+        bufferInfo.size = totalBufferSize;
+        bufferInfo.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+        bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+        if (vkCreateBuffer(device->getLogicalDevice(), &bufferInfo, nullptr, &buffers[i]) != VK_SUCCESS) {
+            throw std::runtime_error("Failed to create dynamic uniform buffer!");
+        }
+
+        // Get memory requirements
+        VkMemoryRequirements memRequirements;
+        vkGetBufferMemoryRequirements(device->getLogicalDevice(), buffers[i], &memRequirements);
+
+        // Allocate memory
+        VkMemoryAllocateInfo allocInfo{};
+        allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+        allocInfo.allocationSize = memRequirements.size;
+        allocInfo.memoryTypeIndex = device->findMemoryType(
+            memRequirements.memoryTypeBits,
+            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT
+        );
+
+        if (vkAllocateMemory(device->getLogicalDevice(), &allocInfo, nullptr, &memories[i]) != VK_SUCCESS) {
+            throw std::runtime_error("Failed to allocate dynamic uniform buffer memory!");
+        }
+
+        // Bind buffer to memory
+        vkBindBufferMemory(device->getLogicalDevice(), buffers[i], memories[i], 0);
+
+        // Map memory for persistent mapping
+        vkMapMemory(device->getLogicalDevice(), memories[i], 0, totalBufferSize, 0, &mappedMemory[i]);
+
+        // Initialize memory to zero
+        memset(mappedMemory[i], 0, totalBufferSize);
+    }
+}
+
+void DynamicUBO::cleanupBuffers() {
+    for (uint32_t i = 0; i < framesInFlight; ++i) {
+        if (mappedMemory[i]) {
+            vkUnmapMemory(device->getLogicalDevice(), memories[i]);
+        }
+        if (buffers[i]) {
+            vkDestroyBuffer(device->getLogicalDevice(), buffers[i], nullptr);
+        }
+        if (memories[i]) {
+            vkFreeMemory(device->getLogicalDevice(), memories[i], nullptr);
+        }
+    }
+    buffers.clear();
+    memories.clear();
+    mappedMemory.clear();
+}
+
+void DynamicUBO::updateObjectTransform(uint32_t frameIndex, uint32_t objectIndex, const Matrix4& modelMatrix) {
+    if (frameIndex >= framesInFlight) {
+        throw std::runtime_error("Frame index out of bounds");
+    }
+    if (objectIndex >= maxObjects) {
+        throw std::runtime_error("Object index out of bounds");
+    }
+
+    // Calculate offset for this object
+    size_t offset = objectIndex * alignedObjectSize;
+
+    // Get pointer to this object's data in the buffer
+    uint8_t* bufferData = static_cast<uint8_t*>(mappedMemory[frameIndex]);
+    PerObjectData* objectData = reinterpret_cast<PerObjectData*>(bufferData + offset);
+
+    // Copy model matrix
+    memcpy(objectData->model, modelMatrix.data(), sizeof(objectData->model));
+
+    // For normal matrix, we'll use the model matrix for now
+    // In a proper implementation, this should be inverse transpose of the upper-left 3x3
+    // But for basic rendering, the model matrix works if there's no non-uniform scaling
+    memcpy(objectData->normalMatrix, modelMatrix.data(), sizeof(objectData->normalMatrix));
+}
+
+uint32_t DynamicUBO::getDynamicOffset(uint32_t objectIndex) const {
+    return objectIndex * alignedObjectSize;
+}
+
+VkDescriptorBufferInfo DynamicUBO::getDescriptorBufferInfo(uint32_t frameIndex) const {
+    VkDescriptorBufferInfo bufferInfo{};
+    bufferInfo.buffer = buffers[frameIndex];
+    bufferInfo.offset = 0;
+    bufferInfo.range = alignedObjectSize;  // Size of one object's data
+    return bufferInfo;
+}

--- a/src/rendering/DynamicUBO.h
+++ b/src/rendering/DynamicUBO.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <vector>
+#include <cstdint>
+
+class VulkanDevice;
+class Matrix4;
+
+// DynamicUBO manages a single large uniform buffer that contains transforms for multiple objects
+// Each object's data is aligned according to GPU requirements for dynamic offsets
+class DynamicUBO {
+public:
+    // Structure matching the shader's per-object uniform block
+    struct PerObjectData {
+        alignas(16) float model[16];      // Model matrix
+        alignas(16) float normalMatrix[16]; // Normal matrix (inverse transpose of model)
+    };
+
+    DynamicUBO(VulkanDevice* device, uint32_t maxObjects, uint32_t framesInFlight);
+    ~DynamicUBO();
+
+    // Update the transform for a specific object in a specific frame
+    void updateObjectTransform(uint32_t frameIndex, uint32_t objectIndex, const Matrix4& modelMatrix);
+
+    // Get the dynamic offset for a specific object
+    uint32_t getDynamicOffset(uint32_t objectIndex) const;
+
+    // Get the aligned size of each object's data
+    uint32_t getAlignedObjectSize() const { return alignedObjectSize; }
+
+    // Get the buffer for a specific frame
+    VkBuffer getBuffer(uint32_t frameIndex) const { return buffers[frameIndex]; }
+
+    // Get descriptor buffer info for binding
+    VkDescriptorBufferInfo getDescriptorBufferInfo(uint32_t frameIndex) const;
+
+private:
+    void createBuffers();
+    void cleanupBuffers();
+
+    VulkanDevice* device;
+    uint32_t maxObjects;
+    uint32_t framesInFlight;
+    uint32_t alignedObjectSize;
+    size_t totalBufferSize;
+
+    // Per-frame buffers for double/triple buffering
+    std::vector<VkBuffer> buffers;
+    std::vector<VkDeviceMemory> memories;
+    std::vector<void*> mappedMemory;
+};

--- a/src/rendering/Renderer.h
+++ b/src/rendering/Renderer.h
@@ -9,9 +9,10 @@ class VulkanPipeline;
 class Camera;
 class Model;
 class Light;
+class DynamicUBO;
 
-struct UniformBufferObject {
-    alignas(16) float model[16];
+// Global uniform data that's the same for all objects
+struct GlobalUniformData {
     alignas(16) float view[16];
     alignas(16) float proj[16];
     alignas(16) float lightPos[4];
@@ -37,11 +38,12 @@ public:
 private:
     void createDescriptorSetLayout();
     void createGraphicsPipeline();
-    void createUniformBuffers();
+    void createGlobalUniformBuffers();
     void createDescriptorPool();
     void createDescriptorSets();
-    
-    void updateUniformBuffer(uint32_t currentFrame);
+
+    void updateGlobalUniformBuffer(uint32_t currentFrame);
+    void updateDynamicUBO(uint32_t currentFrame);
     void recordCommandBuffer(VkCommandBuffer commandBuffer);
     
     VulkanEngine& engine;
@@ -54,11 +56,16 @@ private:
     VkDescriptorSetLayout descriptorSetLayout;
     VkDescriptorPool descriptorPool;
     std::vector<VkDescriptorSet> descriptorSets;
-    
-    std::vector<VkBuffer> uniformBuffers;
-    std::vector<VkDeviceMemory> uniformBuffersMemory;
-    std::vector<void*> uniformBuffersMapped;
-    
+
+    // Global uniform buffers (view, proj, lighting)
+    std::vector<VkBuffer> globalUniformBuffers;
+    std::vector<VkDeviceMemory> globalUniformBuffersMemory;
+    std::vector<void*> globalUniformBuffersMapped;
+
+    // Dynamic UBO for per-object transforms
+    std::unique_ptr<DynamicUBO> dynamicUBO;
+
 	uint32_t currentFrame;
     static const int MAX_FRAMES_IN_FLIGHT = 2;
+    static const uint32_t MAX_OBJECTS = 1000;
 };

--- a/src/vulkan/VulkanPipeline.cpp
+++ b/src/vulkan/VulkanPipeline.cpp
@@ -168,7 +168,7 @@ void VulkanPipeline::createGraphicsPipeline() {
     rasterizer.polygonMode = VK_POLYGON_MODE_FILL;
     rasterizer.lineWidth = 1.0f;
     rasterizer.cullMode = VK_CULL_MODE_BACK_BIT;
-    rasterizer.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    rasterizer.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;  // Counter-clockwise to match OpenGL models
     rasterizer.depthBiasEnable = VK_FALSE;
     
     // Multisampling


### PR DESCRIPTION
Might as well make this jump now, if we expect to handle lots of objects later.  Also significantly improves "what is in the 3D world that is rendered" and the overall quality of that rendering, which should all now be correct (was previously having issues with models appearing to be rendered "inside-out").  Models should also now all wrap CCW, consistent with models ubiquitously targeting OpenGL.  Still does have one flaw:  camera does not start out looking at scene, so must impart (hack) an initial rotation, indicating incorrect `lookAt()` method.